### PR TITLE
add encoding in parse response

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -157,7 +157,7 @@ adjust.cohorts <- function(app.token=NULL, tracker.token=NULL, ...) {
     stop(content(resp))
   }
 
-  data.table(content(resp))
+  data.table(content(resp,encoding="UTF-8"))
 }
 
 .api.path <- function(app.token, resource=NULL, tracker.token=NULL) {


### PR DESCRIPTION
once there are non-ascii encoding characters in the response, the original method will messed up the strings.
