### PR TITLE
Provide better debugging on HTTP error

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -214,6 +214,7 @@ adjust.cohorts <- function(app.token=NULL, tracker.token=NULL, ...) {
   }
 
   if (status_code(resp) != 200) {
+    warning('Unexpected HTTP response code from the KPI service: ', status_code(resp))
     stop(content(resp))
   }
 


### PR DESCRIPTION
This will output the HTTP error code in addition to response body on HTTP error.