### PR TITLE
Enforce Bigint for integer classes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: adjust
 Type: Package
 Title: R client for the adjust.com API
-Version: 0.0.5
+Version: 0.1.0
 Date: 2015-05-13
 Author: Nikola Chochkov
 Maintainer: Nikola Chochkov <nikola@adjust.com>

--- a/R/client.R
+++ b/R/client.R
@@ -224,7 +224,24 @@ adjust.cohorts <- function(app.token=NULL, tracker.token=NULL, ...) {
   }
 
   # We choose to parse the response using data.table::fread instead of readr::read_csv, which is the default in httr.
-  data.table::fread(content(resp, as='text', encoding="UTF-8"))
+  res <- data.table::fread(content(resp, as='text', encoding='UTF-8'), integer64='numeric')
+
+  # Perform some parsing of the data.table columns
+  for (col in colnames(res)) {
+    # We treat NAs as 0 except in non-empty names/tokens
+    if (class(res[[col]]) != 'character') {
+      val <- res[[col]]
+      val[is.na(val)] <- 0
+      set(res, j=col, value=val)
+    }
+
+    # For consistency all integer class columns are converted to Numeric
+    if (class(res[[col]]) == 'integer') {
+      set(res, j=col, value=as.numeric(res[[col]]))
+    }
+  }
+
+  res
 }
 
 .api.path <- function(app.token, resource=NULL, tracker.token=NULL) {

--- a/R/client.R
+++ b/R/client.R
@@ -3,8 +3,8 @@
 .TRACKERS.ROUTE <- 'trackers'
 .ACCEPT.HEADER <- 'text/csv'
 .AUTHORIZATION.HEADER <- 'Token token=%s'
-.LIST.QUERY.PARAMS <- c('kpis', 'countries', 'os_names', 'device_types', 'grouping', 'events', 'tracker_filter', 'impression_based')
-.VALUE.QUERY.PARAMS <- c('start_date', 'end_date', 'sandbox', 'period')
+.LIST.QUERY.PARAMS <- c('kpis', 'countries', 'os_names', 'device_types', 'grouping', 'events', 'tracker_filter')
+.VALUE.QUERY.PARAMS <- c('start_date', 'end_date', 'sandbox', 'period', 'impression_based')
 
 .AdjustRuntimeEnv <- new.env()
 


### PR DESCRIPTION
Fixes an issue in which result sets from similar requests could have either int or bigint types depending on the numbers in the response.